### PR TITLE
Removed offline packages from nuget.config

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -5,7 +5,6 @@
     <add key="automatic" value="True" />
   </packageRestore>
   <packageSources>
-    <add key="offline_packages" value=".\offline_packages\" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Is not needed anymore, since the interface is already on NuGet.org.