### PR TITLE
added end of failure receipt [zero-receipt]

### DIFF
--- a/src/fiskaltrust.Middleware.Demo/ReceiptExamples/zero-receipt/end-of-failure-receipt.json
+++ b/src/fiskaltrust.Middleware.Demo/ReceiptExamples/zero-receipt/end-of-failure-receipt.json
@@ -1,0 +1,10 @@
+{
+  "ftReceiptCase": 4919338172267102210,
+  "ftCashBoxID": "c094f242-91d5-4343-9c54-bce85f70d0d6",
+  "ftPosSystemId": "b3dc6573-96d9-e611-80f7-5065f38adae1",
+  "cbTerminalID": "CashDesk1",
+  "cbReceiptReference": "ZeroReceiptAfterFailure",
+  "cbReceiptMoment": "2020-03-25T13:32:45.133Z",
+  "cbChargeItems": [],
+  "cbPayItems": []
+}


### PR DESCRIPTION
Sending end of failure receipt will end sscd-failed-mode, resetting SSCDFailCount, SSCDFailMoment and SSCDFailQueueItemId.