### PR TITLE
Update samples to use the new ftSignatureFormat flag

### DIFF
--- a/src/fiskaltrust.Middleware.Demo.Shared/CaseExtensions.cs
+++ b/src/fiskaltrust.Middleware.Demo.Shared/CaseExtensions.cs
@@ -1,0 +1,7 @@
+﻿namespace fiskaltrust.Middleware.Demo.Shared
+{
+    public static class CaseExtensions
+    {
+        public static bool HasFlag(this long cse, long flag) => (cse & flag) == flag;
+    }
+}


### PR DESCRIPTION
This PR changes the samples to follow some best practices:
- [x] Print depending on the new ftSignatureFormatFlag
- [x] Distinguish between printing methods by the format in a loop